### PR TITLE
Change JSON encoding flag from JSON_ENSURE_ASCII to JSON_COMPACT.

### DIFF
--- a/src/apn.c
+++ b/src/apn.c
@@ -648,7 +648,7 @@ static char * __apn_create_json_document_from_payload(apn_payload_ctx_ref payloa
         }
     }
 
-    json_document = json_dumps(root, JSON_ENSURE_ASCII);
+    json_document = json_dumps(root, JSON_COMPACT);
     json_decref(root);
     return json_document;
 }


### PR DESCRIPTION
JSON_COMPACT results in a, as the name suggests, more compact JSON
representation allowing to send more characters as part of a push
notification. Further, not using JSON_ENSURE_ASCII is necessary
for languages that do not use the latin alphabet (Arabic, CJK, etc),
otherwise the character limit for notifications is ridiculously
short.