### PR TITLE
1.1.0 release includes an empty directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,8 @@ INCLUDE(ExternalProject)
 
 ExternalProject_Add(
     jansson
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jansson"
-    #GIT_REPOSITORY git://github.com/akheron/jansson.git
+    #SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jansson"
+    GIT_REPOSITORY git://github.com/akheron/jansson.git
     BINARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jansson"
     INSTALL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/jansson"
     CMAKE_COMMAND cmake .


### PR DESCRIPTION
This means the SOURCE_DIR won't work. We need a GIT_REPOSITORY or a release with actual files in that folder. GIT_REPOSITORY seems like the best solution to me.