### PR TITLE
1.1.0-never_closed_socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 libcapn is a C Library to interact with the [Apple Push Notification Service](http://developer.apple.com/library/mac/#documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/ApplePushService/ApplePushService.html) using simple and intuitive API. 
 With the library you can easily send push notifications to iOS and OS X (>= 10.8) devices. 
 
-> Experimental version 2.0 can be found here: https://github.com/adobkin/libcapn/tree/experimental
-
 ##LICENSE##
 
 The library is licensed under the [MIT](http://www.opensource.org/licenses/mit-license.php) license; see LICENSE file.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The library is licensed under the [MIT](http://www.opensource.org/licenses/mit-l
 
 ##DOCUMENTATION##
 
-- [View documentation](http://libcapn.org/doc/html/index.html)
+- [View documentation](http://libcapn.org/doc/1.0/index.html)
 
 ##BINDINGS##
 
@@ -19,7 +19,7 @@ The library is licensed under the [MIT](http://www.opensource.org/licenses/mit-l
 
 ##EXAMPLE##
 
-- [Send Push Notification](http://libcapn.org/doc/html/send_push_8c-example.html)
-- [Feedback Service](http://libcapn.org/doc/html/feedback_8c-example.html)
+- [Send Push Notification](http://libcapn.org/doc/1.0/send_push_8c-example.html)
+- [Feedback Service](http://libcapn.org/doc/1.0/feedback_8c-example.html)
 
 


### PR DESCRIPTION
When connect() failed in __apn_connect(), socket is never closed.